### PR TITLE
refactor: reduce iterations in validate new multisig

### DIFF
--- a/x/core/01_interchain_security/types/merkle_root_multisig_test.go
+++ b/x/core/01_interchain_security/types/merkle_root_multisig_test.go
@@ -68,7 +68,7 @@ var _ = Describe("merkle_root_multisig.go", Ordered, func() {
 		}
 
 		// Assert
-		Expect(messageIdMultisigIsm.Validate().Error()).To(Equal("invalid validator address: must be ethereum address (20 bytes)"))
+		Expect("invalid validator address: must be 20 bytes").To(Equal(messageIdMultisigIsm.Validate().Error()))
 	})
 
 	It("Validate (invalid) unsorted validators", func() {

--- a/x/core/01_interchain_security/types/message_id_multisig_test.go
+++ b/x/core/01_interchain_security/types/message_id_multisig_test.go
@@ -66,7 +66,7 @@ var _ = Describe("message_id_multisig.go", Ordered, func() {
 		}
 
 		// Assert
-		Expect(messageIdMultisigIsm.Validate().Error()).To(Equal("invalid validator address: must be ethereum address (20 bytes)"))
+		Expect("invalid validator address: must be 20 bytes").To(Equal(messageIdMultisigIsm.Validate().Error()))
 	})
 
 	It("Validate (invalid) unsorted validators", func() {


### PR DESCRIPTION
## Description

Small refactor to the `ValidateNewMultisig` function to:

- Reduce the number of iterations by 1 for validators.
- Remove reference to Ethereum in docstring for bytes (bytes are just bytes)
- Use same docstring format for the entire function (first capital letter and final period)