### PR TITLE
yjamin: query cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,17 +24,19 @@ An '!' indicates a state machine breaking change.
 ### Improvements
 
 - [#99](https://github.com/bcp-innovations/hyperlane-cosmos/pull/99) Add registration queries for routers, extract create mailbox logic
+- [#102](https://github.com/bcp-innovations/hyperlane-cosmos/pull/102) Add Query Commands for CLI
 
 ## [v1.0.0-beta0](https://github.com/bcp-innovations/hyperlane-cosmos/releases/tag/v1.0.0-beta0) - 2025-03-27
 
 **Initial Release of the Hyperlane Cosmos SDK Module** 🚀
 
-This module integrates the **Hyperlane messaging protocol** 
-([Hyperlane Docs](https://docs.hyperlane.xyz/)), enabling seamless interchain 
-communication. It also provides full support for **token bridges**, 
+This module integrates the **Hyperlane messaging protocol**
+([Hyperlane Docs](https://docs.hyperlane.xyz/)), enabling seamless interchain
+communication. It also provides full support for **token bridges**,
 secured by **multi-signature Interchain Security Modules**.
 
 ### **Key Features**
+
 - **Mailbox Functionality** – Send and receive messages securely across chains.
 - **Warp Routes (Token Bridging)**
   - **Collateral Tokens** – Native asset bridging.
@@ -48,5 +50,5 @@ secured by **multi-signature Interchain Security Modules**.
   - **Merkle Tree Hook** – Supports Merkle-based verification for Multisig ISMs.
   - **InterchainGasPaymaster** – Provides gas prices for destination chains and interchain gas payments.
 
-The module includes a comprehensive test suite and a preconfigured minimal 
+The module includes a comprehensive test suite and a preconfigured minimal
 Cosmos SDK app.

--- a/x/core/01_interchain_security/client/cli/query.go
+++ b/x/core/01_interchain_security/client/cli/query.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/bcp-innovations/hyperlane-cosmos/x/core/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/spf13/cobra"
+)
+
+// GetQueryCmd returns the cli query commands for this module
+func GetQueryCmd(queryRoute string) *cobra.Command {
+	// Group query queries under a subcommand
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	return cmd
+}

--- a/x/core/01_interchain_security/client/cli/query.go
+++ b/x/core/01_interchain_security/client/cli/query.go
@@ -11,7 +11,6 @@ import (
 
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd() *cobra.Command {
-
 	// Group query queries under a subcommand
 	cmd := &cobra.Command{
 		Use:                        types.SubModuleName,

--- a/x/core/01_interchain_security/client/cli/query.go
+++ b/x/core/01_interchain_security/client/cli/query.go
@@ -3,21 +3,160 @@ package cli
 import (
 	"fmt"
 
-	"github.com/bcp-innovations/hyperlane-cosmos/x/core/types"
+	"github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security/types"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 )
 
 // GetQueryCmd returns the cli query commands for this module
-func GetQueryCmd(queryRoute string) *cobra.Command {
+func GetQueryCmd() *cobra.Command {
+
 	// Group query queries under a subcommand
 	cmd := &cobra.Command{
-		Use:                        types.ModuleName,
-		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),
+		Use:                        types.SubModuleName,
+		Short:                      fmt.Sprintf("Querying commands for the %s module", types.SubModuleName),
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
+
+	cmd.AddCommand(CmdIsms(),
+		CmdIsm(),
+		CmdAnnouncedStorageLocations(),
+		CmdLatestAnnouncedStorageLocation(),
+	)
+
+	return cmd
+}
+
+func CmdIsms() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "isms",
+		Short: "List all ISMs",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			params := &types.QueryIsmsRequest{
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.Isms(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "isms")
+
+	return cmd
+}
+
+func CmdIsm() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ism [id]",
+		Short: "Get ISM details by ID",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryIsmRequest{
+				Id: args[0],
+			}
+
+			res, err := queryClient.Ism(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdAnnouncedStorageLocations() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "announced-storage-locations [mailbox-id] [validator-address]",
+		Short: "Query announced storage locations for a validator",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryAnnouncedStorageLocationsRequest{
+				MailboxId:        args[0],
+				ValidatorAddress: args[1],
+			}
+
+			res, err := queryClient.AnnouncedStorageLocations(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdLatestAnnouncedStorageLocation() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "latest-announced-storage-location [mailbox-id] [validator-address]",
+		Short: "Query the latest announced storage location for a validator",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryLatestAnnouncedStorageLocationRequest{
+				MailboxId:        args[0],
+				ValidatorAddress: args[1],
+			}
+
+			res, err := queryClient.LatestAnnouncedStorageLocation(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd
 }

--- a/x/core/01_interchain_security/module.go
+++ b/x/core/01_interchain_security/module.go
@@ -1,16 +1,20 @@
 package interchain_security
 
 import (
+	"github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security/client/cli"
 	"github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security/types"
 	"github.com/cosmos/gogoproto/grpc"
 	"github.com/spf13/cobra"
 )
 
-import "github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security/client/cli"
-
 // GetTxCmd returns the root command for the core ISMs
 func GetTxCmd() *cobra.Command {
 	return cli.GetTxCmd()
+}
+
+// GetQueryCmd returns the root command for the core ISMs
+func GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd()
 }
 
 // RegisterMsgServer registers the core ism handler for transactions

--- a/x/core/02_post_dispatch/client/cli/query.go
+++ b/x/core/02_post_dispatch/client/cli/query.go
@@ -12,7 +12,6 @@ import (
 
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd() *cobra.Command {
-
 	// Group query queries under a subcommand
 	cmd := &cobra.Command{
 		Use:                        "hooks",

--- a/x/core/02_post_dispatch/client/cli/query.go
+++ b/x/core/02_post_dispatch/client/cli/query.go
@@ -1,0 +1,306 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bcp-innovations/hyperlane-cosmos/x/core/02_post_dispatch/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+)
+
+// GetQueryCmd returns the cli query commands for this module
+func GetQueryCmd() *cobra.Command {
+
+	// Group query queries under a subcommand
+	cmd := &cobra.Command{
+		Use:                        "hooks",
+		Short:                      fmt.Sprintf("Querying commands for the %s module", strings.Replace(types.SubModuleName, "_", "-", 1)),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(CmdIgps(),
+		CmdIgp(),
+		CmdDestinationGasConfigs(),
+		CmdQuoteGasPayment(),
+		CmdMerkleTreeHooks(),
+		CmdMerkleTreeHook(),
+		CmdNoopHooks(),
+		CmdNoopHook(),
+	)
+	return cmd
+}
+
+func CmdIgps() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "igps",
+		Short: "List all interchain gas paymasters",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			params := &types.QueryIgpsRequest{
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.Igps(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "igps")
+
+	return cmd
+}
+
+func CmdIgp() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "igp [id]",
+		Short: "Get details for a specific interchain gas paymaster",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryIgpRequest{
+				Id: args[0],
+			}
+
+			res, err := queryClient.Igp(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdDestinationGasConfigs() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "destination-gas-configs [id]",
+		Short: "List destination gas configs for an IGP",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			params := &types.QueryDestinationGasConfigsRequest{
+				Id:         args[0],
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.DestinationGasConfigs(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "destination-gas-configs")
+
+	return cmd
+}
+
+func CmdQuoteGasPayment() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "quote-gas-payment [igp-id] [destination-domain] [gas-limit]",
+		Short: "Quote gas payment for a transaction",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryQuoteGasPaymentRequest{
+				IgpId:             args[0],
+				DestinationDomain: args[1],
+				GasLimit:          args[2],
+			}
+
+			res, err := queryClient.QuoteGasPayment(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdMerkleTreeHooks() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "merkle-tree-hooks",
+		Short: "List all merkle tree hooks",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			params := &types.QueryMerkleTreeHooksRequest{
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.MerkleTreeHooks(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "merkle-tree-hooks")
+
+	return cmd
+}
+
+func CmdMerkleTreeHook() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "merkle-tree-hook [id]",
+		Short: "Get details for a specific merkle tree hook",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryMerkleTreeHookRequest{
+				Id: args[0],
+			}
+
+			res, err := queryClient.MerkleTreeHook(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdNoopHooks() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "noop-hooks",
+		Short: "List all noop hooks",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			params := &types.QueryNoopHooksRequest{
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.NoopHooks(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "noop-hooks")
+
+	return cmd
+}
+
+func CmdNoopHook() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "noop-hook [id]",
+		Short: "Get details for a specific noop hook",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryNoopHookRequest{
+				Id: args[0],
+			}
+
+			res, err := queryClient.NoopHook(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/core/02_post_dispatch/module.go
+++ b/x/core/02_post_dispatch/module.go
@@ -12,7 +12,7 @@ func GetTxCmd() *cobra.Command {
 	return cli.GetTxCmd()
 }
 
-// GetQueryCmd returns the root command for the core ISMs
+// GetQueryCmd returns the root command for the core post dispatch hooks
 func GetQueryCmd() *cobra.Command {
 	return cli.GetQueryCmd()
 }

--- a/x/core/02_post_dispatch/module.go
+++ b/x/core/02_post_dispatch/module.go
@@ -12,6 +12,11 @@ func GetTxCmd() *cobra.Command {
 	return cli.GetTxCmd()
 }
 
+// GetQueryCmd returns the root command for the core ISMs
+func GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd()
+}
+
 // RegisterMsgServer registers the post dispatch hook handler for transactions
 func RegisterMsgServer(server grpc.Server, msgServer types.MsgServer) {
 	types.RegisterMsgServer(server, msgServer)

--- a/x/core/client/cli/query.go
+++ b/x/core/client/cli/query.go
@@ -1,0 +1,293 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/bcp-innovations/hyperlane-cosmos/x/core/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+
+	ism "github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security"
+	post_dispatch "github.com/bcp-innovations/hyperlane-cosmos/x/core/02_post_dispatch"
+)
+
+// GetQueryCmd returns the cli query commands for this module
+func GetQueryCmd() *cobra.Command {
+	// Group query queries under a subcommand
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		ism.GetQueryCmd(),
+		post_dispatch.GetQueryCmd(),
+	)
+
+	cmd.AddCommand(CmdMailboxes(),
+		CmdMailbox(),
+		CmdDelivered(),
+		CmdRecipientIsm(),
+		CmdVerifyDryRun(),
+		CmdRegisteredISMs(),
+		CmdRegisteredHooks(),
+		CmdRegisteredApps(),
+	)
+
+	return cmd
+}
+
+func CmdMailboxes() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mailboxes",
+		Short: "List all mailboxes",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			params := &types.QueryMailboxesRequest{
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.Mailboxes(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "mailboxes")
+
+	return cmd
+}
+
+func CmdMailbox() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mailbox [id]",
+		Short: "Get mailbox details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryMailboxRequest{
+				Id: args[0],
+			}
+
+			res, err := queryClient.Mailbox(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdDelivered() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delivered [mailbox-id] [message-id]",
+		Short: "Check if a message has been delivered",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryDeliveredRequest{
+				Id:        args[0],
+				MessageId: args[1],
+			}
+
+			res, err := queryClient.Delivered(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdRecipientIsm() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "recipient-ism [recipient]",
+		Short: "Get ISM ID for a recipient",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryRecipientIsmRequest{
+				Recipient: args[0],
+			}
+
+			res, err := queryClient.RecipientIsm(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdVerifyDryRun() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify-dry-run [ism-id] [message] [metadata] [gas-limit]",
+		Short: "Perform a dry run verification of a message",
+		Args:  cobra.ExactArgs(4),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryVerifyDryRunRequest{
+				IsmId:    args[0],
+				Message:  args[1],
+				Metadata: args[2],
+				GasLimit: args[3],
+			}
+
+			res, err := queryClient.VerifyDryRun(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdRegisteredISMs() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registered-isms",
+		Short: "List all registered ISMs",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryRegisteredISMs{}
+
+			res, err := queryClient.RegisteredISMs(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdRegisteredHooks() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registered-hooks",
+		Short: "List all registered hooks",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryRegisteredHooks{}
+
+			res, err := queryClient.RegisteredHooks(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdRegisteredApps() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registered-apps",
+		Short: "List all registered applications",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryRegisteredApps{}
+
+			res, err := queryClient.RegisteredApps(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/core/client/cli/tx.go
+++ b/x/core/client/cli/tx.go
@@ -3,13 +3,12 @@ package cli
 import (
 	"fmt"
 
-	pdmodule "github.com/bcp-innovations/hyperlane-cosmos/x/core/02_post_dispatch"
-
+	"github.com/bcp-innovations/hyperlane-cosmos/x/core/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
 	ism "github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security"
-	"github.com/bcp-innovations/hyperlane-cosmos/x/core/types"
+	pdmodule "github.com/bcp-innovations/hyperlane-cosmos/x/core/02_post_dispatch"
 )
 
 var (

--- a/x/core/module.go
+++ b/x/core/module.go
@@ -144,3 +144,8 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 func (am AppModule) GetTxCmd() *cobra.Command {
 	return cli.GetTxCmd()
 }
+
+// GetQueryCmd implements AppModuleBasic interface
+func (am AppModule) GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd()
+}

--- a/x/warp/client/cli/query.go
+++ b/x/warp/client/cli/query.go
@@ -36,7 +36,6 @@ func CmdTokens() *cobra.Command {
 		Short: "List all tokens",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
@@ -66,7 +65,6 @@ func CmdToken() *cobra.Command {
 		Short: "Get token details",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err

--- a/x/warp/client/cli/query.go
+++ b/x/warp/client/cli/query.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/bcp-innovations/hyperlane-cosmos/x/warp/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+)
+
+// GetQueryCmd returns the cli query commands for this module
+func GetQueryCmd() *cobra.Command {
+	// Group query queries under a subcommand
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(CmdTokens())
+	cmd.AddCommand(CmdToken())
+	cmd.AddCommand(CmdBridgedSupply())
+	cmd.AddCommand(CmdRemoteRouters())
+	cmd.AddCommand(CmdQuoteRemoteTransfer())
+
+	return cmd
+}
+
+func CmdTokens() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tokens",
+		Short: "List all tokens",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryTokensRequest{}
+
+			res, err := queryClient.Tokens(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdToken() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "token [id]",
+		Short: "Get token details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryTokenRequest{
+				Id: args[0],
+			}
+
+			res, err := queryClient.Token(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdBridgedSupply() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bridged-supply [id]",
+		Short: "Query bridged supply of a token",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryBridgedSupplyRequest{
+				Id: args[0],
+			}
+
+			res, err := queryClient.BridgedSupply(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdRemoteRouters() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remote-routers [id]",
+		Short: "Query remote routers for a token",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			params := &types.QueryRemoteRoutersRequest{
+				Id:         args[0],
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.RemoteRouters(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "remote-routers")
+
+	return cmd
+}
+
+func CmdQuoteRemoteTransfer() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "quote-transfer [id] [destination-domain]",
+		Short: "Quote gas payment for a remote transfer",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryQuoteRemoteTransferRequest{
+				Id:                args[0],
+				DestinationDomain: args[1],
+			}
+
+			res, err := queryClient.QuoteRemoteTransfer(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/warp/client/cli/query.go
+++ b/x/warp/client/cli/query.go
@@ -16,6 +16,7 @@ func GetQueryCmd() *cobra.Command {
 		Use:                        types.ModuleName,
 		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),
 		DisableFlagParsing:         true,
+		Aliases:                    []string{"hyperlane-transfer"},
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/warp/client/cli/query.go
+++ b/x/warp/client/cli/query.go
@@ -20,12 +20,12 @@ func GetQueryCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	cmd.AddCommand(CmdTokens())
-	cmd.AddCommand(CmdToken())
-	cmd.AddCommand(CmdBridgedSupply())
-	cmd.AddCommand(CmdRemoteRouters())
-	cmd.AddCommand(CmdQuoteRemoteTransfer())
-
+	cmd.AddCommand(CmdTokens(),
+		CmdToken(),
+		CmdBridgedSupply(),
+		CmdRemoteRouters(),
+		CmdQuoteRemoteTransfer(),
+	)
 	return cmd
 }
 

--- a/x/warp/client/cli/tx.go
+++ b/x/warp/client/cli/tx.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"fmt"
+
+	"github.com/bcp-innovations/hyperlane-cosmos/x/warp/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 )
@@ -17,8 +20,9 @@ var (
 
 func GetTxCmd() *cobra.Command {
 	txCmd := &cobra.Command{
-		Use:                        "hyperlane-transfer",
-		Short:                      "hyperlane-transfer transactions subcommands",
+		Use:                        types.ModuleName,
+		Short:                      fmt.Sprintf("%v transactions subcommands", types.ModuleName),
+		Aliases:                    []string{"hyperlane-transfer"},
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,

--- a/x/warp/module.go
+++ b/x/warp/module.go
@@ -113,3 +113,8 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 func (am AppModule) GetTxCmd() *cobra.Command {
 	return cli.GetTxCmd()
 }
+
+// GetQueryCmd implements AppModuleBasic interface
+func (am AppModule) GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd()
+}


### PR DESCRIPTION
Added query commands in the CLI for every module. 

Drive by changes: renamed TX command `hyperlane-transfer` to `warp`. Added alias for backwards compatibility.

Closes #101 