### PR TITLE
chore: register amino types

### DIFF
--- a/tests/hypd/commands.go
+++ b/tests/hypd/commands.go
@@ -20,6 +20,7 @@ import (
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 )
@@ -38,6 +39,7 @@ func initRootCmd(rootCmd *cobra.Command, txConfig client.TxConfig, basicManager 
 
 	rootCmd.AddCommand(
 		genutilcli.Commands(txConfig, basicManager, simapp.DefaultNodeHome),
+		txCommand(),
 		keys.Commands(),
 	)
 }
@@ -51,6 +53,32 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts serverty
 	}
 
 	return app
+}
+
+func txCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        "tx",
+		Short:                      "Transactions subcommands",
+		DisableFlagParsing:         false,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		authcmd.GetSignCommand(),
+		authcmd.GetSignBatchCommand(),
+		authcmd.GetMultiSignCommand(),
+		authcmd.GetMultiSignBatchCmd(),
+		authcmd.GetValidateSignaturesCommand(),
+		flags.LineBreak,
+		authcmd.GetBroadcastCommand(),
+		authcmd.GetEncodeCommand(),
+		authcmd.GetDecodeCommand(),
+		authcmd.GetSimulateCmd(),
+	)
+	cmd.PersistentFlags().String(flags.FlagChainID, "", "The network chain ID")
+
+	return cmd
 }
 
 // appExport creates a new app (optionally at a given height) and exports state.

--- a/x/core/01_interchain_security/module.go
+++ b/x/core/01_interchain_security/module.go
@@ -3,6 +3,7 @@ package interchain_security
 import (
 	"github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security/client/cli"
 	"github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/gogoproto/grpc"
 	"github.com/spf13/cobra"
 )
@@ -25,4 +26,16 @@ func RegisterMsgServer(server grpc.Server, msgServer types.MsgServer) {
 // RegisterQueryService registers the gRPC query service for api queries
 func RegisterQueryService(server grpc.Server, queryServer types.QueryServer) {
 	types.RegisterQueryServer(server, queryServer)
+}
+
+// RegisterLegacyAminoCodec registers the mailbox module's types on the LegacyAmino codec.
+func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&types.MsgAnnounceValidator{}, "hyperlane/v1/MsgAnnounceValidator", nil)
+	cdc.RegisterConcrete(&types.MsgCreateMessageIdMultisigIsm{}, "hyperlane/v1/MsgCreateMessageIdMultisigIsm", nil)
+	cdc.RegisterConcrete(&types.MsgCreateMerkleRootMultisigIsm{}, "hyperlane/v1/MsgCreateMerkleRootMultisigIsm", nil)
+	cdc.RegisterConcrete(&types.MsgCreateNoopIsm{}, "hyperlane/v1/MsgCreateNoopIsm", nil)
+	cdc.RegisterConcrete(&types.MsgCreateRoutingIsm{}, "hyperlane/v1/MsgCreateRoutingIsm", nil)
+	cdc.RegisterConcrete(&types.MsgSetRoutingIsmDomain{}, "hyperlane/v1/MsgCreateRoMsgSetRoutingIsmDomainutingIsm", nil)
+	cdc.RegisterConcrete(&types.MsgRemoveRoutingIsmDomain{}, "hyperlane/v1/MsgRemoveRoutingIsmDomain", nil)
+	cdc.RegisterConcrete(&types.MsgUpdateRoutingIsmOwner{}, "hyperlane/v1/MsgUpdateRoutingIsmOwner", nil)
 }

--- a/x/core/02_post_dispatch/module.go
+++ b/x/core/02_post_dispatch/module.go
@@ -3,6 +3,7 @@ package post_dispatch
 import (
 	"github.com/bcp-innovations/hyperlane-cosmos/x/core/02_post_dispatch/client/cli"
 	"github.com/bcp-innovations/hyperlane-cosmos/x/core/02_post_dispatch/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/gogoproto/grpc"
 	"github.com/spf13/cobra"
 )
@@ -25,4 +26,18 @@ func RegisterMsgServer(server grpc.Server, msgServer types.MsgServer) {
 // RegisterQueryService registers the gRPC query service for API queries
 func RegisterQueryService(server grpc.Server, queryServer types.QueryServer) {
 	types.RegisterQueryServer(server, queryServer)
+}
+
+// RegisterLegacyAminoCodec registers the mailbox module's types on the LegacyAmino codec.
+func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&types.MsgClaim{}, "hyperlane/v1/MsgClaim", nil)
+	cdc.RegisterConcrete(&types.MsgCreateIgp{}, "hyperlane/v1/MsgCreateInterchainGasPaymaster", nil)
+	cdc.RegisterConcrete(&types.MsgCreateMerkleTreeHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
+	cdc.RegisterConcrete(&types.MsgPayForGas{}, "hyperlane/v1/MsgPayForGas", nil)
+	cdc.RegisterConcrete(&types.MsgSetDestinationGasConfig{}, "hyperlane/v1/MsgSetDestinationGasConfig", nil)
+	cdc.RegisterConcrete(&types.MsgSetIgpOwner{}, "hyperlane/v1/MsgSetIgpOwner", nil)
+
+	// TODO
+	// Duplicates are not allowed. This will be fixed with https://github.com/bcp-innovations/hyperlane-cosmos/pull/123
+	// cdc.RegisterConcrete(&pdtypes.MsgCreateNoopHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
 }

--- a/x/core/module.go
+++ b/x/core/module.go
@@ -62,26 +62,10 @@ func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&types.MsgProcessMessage{}, "hyperlane/v1/MsgProcessMessage", nil)
 
 	// 01_interchain_security
-	cdc.RegisterConcrete(&ismtypes.MsgAnnounceValidator{}, "hyperlane/v1/MsgAnnounceValidator", nil)
-	cdc.RegisterConcrete(&ismtypes.MsgCreateMessageIdMultisigIsm{}, "hyperlane/v1/MsgCreateMessageIdMultisigIsm", nil)
-	cdc.RegisterConcrete(&ismtypes.MsgCreateMerkleRootMultisigIsm{}, "hyperlane/v1/MsgCreateMerkleRootMultisigIsm", nil)
-	cdc.RegisterConcrete(&ismtypes.MsgCreateNoopIsm{}, "hyperlane/v1/MsgCreateNoopIsm", nil)
-	cdc.RegisterConcrete(&ismtypes.MsgCreateRoutingIsm{}, "hyperlane/v1/MsgCreateRoutingIsm", nil)
-	cdc.RegisterConcrete(&ismtypes.MsgSetRoutingIsmDomain{}, "hyperlane/v1/MsgCreateRoMsgSetRoutingIsmDomainutingIsm", nil)
-	cdc.RegisterConcrete(&ismtypes.MsgRemoveRoutingIsmDomain{}, "hyperlane/v1/MsgRemoveRoutingIsmDomain", nil)
-	cdc.RegisterConcrete(&ismtypes.MsgUpdateRoutingIsmOwner{}, "hyperlane/v1/MsgUpdateRoutingIsmOwner", nil)
+	ismmodule.RegisterLegacyAminoCodec(cdc)
 
 	// 02_post_dispatch
-	cdc.RegisterConcrete(&pdtypes.MsgClaim{}, "hyperlane/v1/MsgClaim", nil)
-	cdc.RegisterConcrete(&pdtypes.MsgCreateIgp{}, "hyperlane/v1/MsgCreateInterchainGasPaymaster", nil)
-	cdc.RegisterConcrete(&pdtypes.MsgCreateMerkleTreeHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
-	cdc.RegisterConcrete(&pdtypes.MsgPayForGas{}, "hyperlane/v1/MsgPayForGas", nil)
-	cdc.RegisterConcrete(&pdtypes.MsgSetDestinationGasConfig{}, "hyperlane/v1/MsgSetDestinationGasConfig", nil)
-	cdc.RegisterConcrete(&pdtypes.MsgSetIgpOwner{}, "hyperlane/v1/MsgSetIgpOwner", nil)
-
-	// TODO: Remove comment
-	// Duplicates are not allowed. This will be fixed with https://github.com/bcp-innovations/hyperlane-cosmos/pull/123
-	// cdc.RegisterConcrete(&pdtypes.MsgCreateNoopHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
+	pdmodule.RegisterLegacyAminoCodec(cdc)
 }
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the mailbox module.

--- a/x/core/module.go
+++ b/x/core/module.go
@@ -81,7 +81,7 @@ func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 
 	// TODO: Remove comment
 	// Duplicates are not allowed. This will be fixed with https://github.com/bcp-innovations/hyperlane-cosmos/pull/123
-	//cdc.RegisterConcrete(&pdtypes.MsgCreateNoopHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
+	// cdc.RegisterConcrete(&pdtypes.MsgCreateNoopHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
 }
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the mailbox module.

--- a/x/core/module.go
+++ b/x/core/module.go
@@ -55,8 +55,30 @@ func (AppModule) Name() string { return types.ModuleName }
 
 // RegisterLegacyAminoCodec registers the mailbox module's types on the LegacyAmino codec.
 // New modules do not need to support Amino.
-func (AppModule) RegisterLegacyAminoCodec(_ *codec.LegacyAmino) {
-	// this is already handled by the proto annotation
+func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	// core
+	cdc.RegisterConcrete(&types.MsgCreateMailbox{}, "hyperlane/v1/MsgCreateMailbox", nil)
+	cdc.RegisterConcrete(&types.MsgSetMailbox{}, "hyperlane/v1/MsgSetMailbox", nil)
+	cdc.RegisterConcrete(&types.MsgProcessMessage{}, "hyperlane/v1/MsgProcessMessage", nil)
+
+	// 01_interchain_security
+	cdc.RegisterConcrete(&ismtypes.MsgAnnounceValidator{}, "hyperlane/v1/MsgAnnounceValidator", nil)
+	cdc.RegisterConcrete(&ismtypes.MsgCreateMessageIdMultisigIsm{}, "hyperlane/v1/MsgCreateMessageIdMultisigIsm", nil)
+	cdc.RegisterConcrete(&ismtypes.MsgCreateMerkleRootMultisigIsm{}, "hyperlane/v1/MsgCreateMerkleRootMultisigIsm", nil)
+	cdc.RegisterConcrete(&ismtypes.MsgCreateNoopIsm{}, "hyperlane/v1/MsgCreateNoopIsm", nil)
+	cdc.RegisterConcrete(&ismtypes.MsgCreateRoutingIsm{}, "hyperlane/v1/MsgCreateRoutingIsm", nil)
+	cdc.RegisterConcrete(&ismtypes.MsgSetRoutingIsmDomain{}, "hyperlane/v1/MsgCreateRoMsgSetRoutingIsmDomainutingIsm", nil)
+	cdc.RegisterConcrete(&ismtypes.MsgRemoveRoutingIsmDomain{}, "hyperlane/v1/MsgRemoveRoutingIsmDomain", nil)
+	cdc.RegisterConcrete(&ismtypes.MsgUpdateRoutingIsmOwner{}, "hyperlane/v1/MsgUpdateRoutingIsmOwner", nil)
+
+	// 02_post_dispatch
+	cdc.RegisterConcrete(&pdtypes.MsgClaim{}, "hyperlane/v1/MsgClaim", nil)
+	cdc.RegisterConcrete(&pdtypes.MsgCreateIgp{}, "hyperlane/v1/MsgCreateInterchainGasPaymaster", nil)
+	cdc.RegisterConcrete(&pdtypes.MsgCreateMerkleTreeHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
+	cdc.RegisterConcrete(&pdtypes.MsgCreateNoopHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
+	cdc.RegisterConcrete(&pdtypes.MsgPayForGas{}, "hyperlane/v1/MsgPayForGas", nil)
+	cdc.RegisterConcrete(&pdtypes.MsgSetDestinationGasConfig{}, "hyperlane/v1/MsgSetDestinationGasConfig", nil)
+	cdc.RegisterConcrete(&pdtypes.MsgSetIgpOwner{}, "hyperlane/v1/MsgSetIgpOwner", nil)
 }
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the mailbox module.

--- a/x/core/module.go
+++ b/x/core/module.go
@@ -75,10 +75,13 @@ func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&pdtypes.MsgClaim{}, "hyperlane/v1/MsgClaim", nil)
 	cdc.RegisterConcrete(&pdtypes.MsgCreateIgp{}, "hyperlane/v1/MsgCreateInterchainGasPaymaster", nil)
 	cdc.RegisterConcrete(&pdtypes.MsgCreateMerkleTreeHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
-	cdc.RegisterConcrete(&pdtypes.MsgCreateNoopHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
 	cdc.RegisterConcrete(&pdtypes.MsgPayForGas{}, "hyperlane/v1/MsgPayForGas", nil)
 	cdc.RegisterConcrete(&pdtypes.MsgSetDestinationGasConfig{}, "hyperlane/v1/MsgSetDestinationGasConfig", nil)
 	cdc.RegisterConcrete(&pdtypes.MsgSetIgpOwner{}, "hyperlane/v1/MsgSetIgpOwner", nil)
+
+	// TODO: Remove comment
+	// Duplicates are not allowed. This will be fixed with https://github.com/bcp-innovations/hyperlane-cosmos/pull/123
+	//cdc.RegisterConcrete(&pdtypes.MsgCreateNoopHook{}, "hyperlane/v1/MsgCreateMerkleTreeHook", nil)
 }
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the mailbox module.

--- a/x/warp/module.go
+++ b/x/warp/module.go
@@ -47,8 +47,13 @@ func (AppModule) Name() string { return types.ModuleName }
 
 // RegisterLegacyAminoCodec registers the warp module's types on the LegacyAmino codec.
 // New modules do not need to support Amino.
-func (AppModule) RegisterLegacyAminoCodec(_ *codec.LegacyAmino) {
-	// already handled by the proto annotation
+func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&types.MsgCreateCollateralToken{}, "hyperlane/v1/MsgCreateCollateralToken", nil)
+	cdc.RegisterConcrete(&types.MsgCreateSyntheticToken{}, "hyperlane/v1/MsgCreateSyntheticToken", nil)
+	cdc.RegisterConcrete(&types.MsgEnrollRemoteRouter{}, "hyperlane/v1/MsgEnrollRemoteRouter", nil)
+	cdc.RegisterConcrete(&types.MsgRemoteTransfer{}, "hyperlane/v1/MsgRemoteTransfer", nil)
+	cdc.RegisterConcrete(&types.MsgSetToken{}, "hyperlane/v1/MsgSetToken", nil)
+	cdc.RegisterConcrete(&types.MsgUnrollRemoteRouter{}, "hyperlane/v1/MsgUnrollRemoteRouter", nil)
 }
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the warp module.


### PR DESCRIPTION
This PR implements `RegisterLegacyAminoCodec` for all modules, registering the amino codec and name manually. This is required for Keplr multisig dashboard support.